### PR TITLE
Better support for activerecord 4.2 initialization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,12 @@
+*   Pass `static: false` in case you don't want initial states to be forced. e.g.
+
+    ```ruby
+    # will set the initial machine state
+    @machines.initialize_states(@object)
+
+    # optionally you can pass the attributes to have that as the initial state
+    @machines.initialize_states(@object, {}, { state: 'finished' })
+
+    # or pass set `static` to false if you want to keep the `object.state` current value
+    @machines.initialize_states(@object, { static: false })
+    ```

--- a/lib/state_machines/machine_collection.rb
+++ b/lib/state_machines/machine_collection.rb
@@ -21,14 +21,17 @@ module StateMachines
     #   Default is true.
     # * <tt>:to</tt> - A hash to write the initialized state to instead of
     #   writing to the object.  Default is to write directly to the object.
-    def initialize_states(object, options = {})
+    def initialize_states(object, options = {}, attributes = {})
       options.assert_valid_keys( :static, :dynamic, :to)
       options = {:static => true, :dynamic => true}.merge(options)
 
       result = yield if block_given?
 
       each_value do |machine| 
-        machine.initialize_state(object, :force => options[:static] == :force, :to => options[:to]) unless machine.dynamic_initial_state?
+        unless machine.dynamic_initial_state?
+          force = options[:static] == :force || !attributes.keys.include?(machine.attribute)
+          machine.initialize_state(object, force: force, :to => options[:to])
+        end
       end if options[:static]
       
       each_value do |machine|

--- a/lib/state_machines/machine_collection.rb
+++ b/lib/state_machines/machine_collection.rb
@@ -1,8 +1,6 @@
 module StateMachines
   # Represents a collection of state machines for a class
   class MachineCollection < Hash
-
-    
     # Initializes the state of each machine in the given object.  This can allow
     # states to be initialized in two groups: static and dynamic.  For example:
     # 
@@ -13,9 +11,9 @@ module StateMachines
     # If no block is provided, then all states will still be initialized.
     # 
     # Valid configuration options:
-    # * <tt>:static</tt> - Whether to initialize static states.  If set to
-    #   :force, the state will be initialized regardless of its current value.
-    #   Default is :force.
+    # * <tt>:static</tt> - Whether to initialize static states. Unless set to
+    #   false, the state will be initialized regardless of its current value.
+    #   Default is true.
     # * <tt>:dynamic</tt> - Whether to initialize dynamic states.  If set to
     #   :force, the state will be initialized regardless of its current value.
     #   Default is true.

--- a/test/unit/machine/machine_with_static_initial_state_test.rb
+++ b/test/unit/machine/machine_with_static_initial_state_test.rb
@@ -29,17 +29,6 @@ class MachineWithStaticInitialStateTest < StateMachinesTest
     assert_equal 'parked', @klass.new.state
   end
 
-  def test_not_set_initial_state_even_if_not_empty
-    @klass.class_eval do
-      def initialize(_attributes = {})
-        self.state = 'idling'
-        super()
-      end
-    end
-    object = @klass.new
-    assert_equal 'idling', object.state
-  end
-
   def test_should_not_initial_state_prior_to_initialization
     base = Class.new do
       attr_accessor :state_on_init

--- a/test/unit/machine_collection/machine_collection_state_initialization_test.rb
+++ b/test/unit/machine_collection/machine_collection_state_initialization_test.rb
@@ -57,10 +57,10 @@ class MachineCollectionStateInitializationTest < StateMachinesTest
     assert_equal 'active', @object.alarm_state
   end
 
-  def test_should_not_initialize_existing_static_states_by_default
+  def test_should_initialize_existing_static_states_by_default
     @object.state = 'idling'
     @machines.initialize_states(@object)
-    assert_equal 'idling', @object.state
+    assert_equal 'parked', @object.state
   end
 
   def test_should_initialize_existing_static_states_if_forced
@@ -69,10 +69,10 @@ class MachineCollectionStateInitializationTest < StateMachinesTest
     assert_equal 'parked', @object.state
   end
 
-  def test_should_not_initialize_existing_static_states_if_not_forced
+  def test_should_initialize_existing_static_states_if_not_forced
     @object.state = 'idling'
     @machines.initialize_states(@object, static: true)
-    assert_equal 'idling', @object.state
+    assert_equal 'parked', @object.state
   end
 
   def test_should_skip_dynamic_states_if_disabled


### PR DESCRIPTION
This is an attempt to get both this build and state_machines-ar builds green.

Currently state_machines-ar has at least 3 issues on latest rails assuming I got this right (features that used to work before):

1. State machines initial states used to override database column defaults,
2. You could set up a field that didn't exist on the database and the state machine could still keep track of it. Helpers method would be defined on the fly and mapped to the `state` column.
3. You could override the state machine initial state by simply passing it around on initialization. e.g. `Post.new state: 'finished'`

I believe the changes here fix those tree issues on the activerecord side. However it changes the way the api for `initialize_states` work. Now if one don't want to force the initial state it has to explicitly pass `static: false` instead, previously it would only force if one passed `static: :force`. Still the fix for # 2 mentioned above I got is [so awful terrible](https://github.com/huoxito/state_machines/blob/9719c5f8f6fef2b305e3079933bfb31d1b8dd718/lib/state_machines/machine.rb#L662-665) I'd rather drop that feature. What you think? wouldn't really want to merge this as is myself

ps. once this is resolved I'd submit https://github.com/huoxito/state_machines-activerecord/compare/4.2-states-initialization to sm-ar and double check if spree builds are ok with the latest version of all these projects.

// @seuros 