### PR TITLE
Give another try on integrations loading issue

### DIFF
--- a/lib/state_machines/integrations.rb
+++ b/lib/state_machines/integrations.rb
@@ -111,12 +111,15 @@ module StateMachines
         integrations.detect { |integration| integration.integration_name == name } || raise(IntegrationNotFound.new(name))
       end
 
-
       private
 
       def name_spaced_integrations
         # FIXME, Integrations should be add before their dependencies.
-        self.constants.reject{ |i| i==:Base }.each do |const|
+        constants = self.constants.reject { |i| i == :Base }
+        constants = constants.map(&:to_s).select { |c| c != 'ActiveModel' }.sort
+        constants << 'ActiveModel' if defined?(ActiveModel)
+
+        constants.each do |const|
           integration = self.const_get(const)
           add(integration)
         end


### PR DESCRIPTION
When using state_machines in a larger project with activerecord (spree)
we were still seeing a ton of errors related to methods not being
defined or constants not being loaded in a proper order.

e.g. activemodel cant appear first on the list of registered
integrations

hopefully a fix for the issue mentioned in https://github.com/state-machines/state_machines-activerecord/issues/2#issuecomment-71980573, spree/core build seems happy about it

// @seuros 