### PR TITLE
to_sym on attributes given to MachineCollection

### DIFF
--- a/lib/state_machines/machine_collection.rb
+++ b/lib/state_machines/machine_collection.rb
@@ -27,7 +27,7 @@ module StateMachines
 
       each_value do |machine| 
         unless machine.dynamic_initial_state?
-          force = options[:static] == :force || !attributes.keys.include?(machine.attribute)
+          force = options[:static] == :force || !attributes.keys.map(&:to_sym).include?(machine.attribute)
           machine.initialize_state(object, force: force, :to => options[:to])
         end
       end if options[:static]

--- a/test/unit/machine_collection/machine_collection_state_initialization_test.rb
+++ b/test/unit/machine_collection/machine_collection_state_initialization_test.rb
@@ -98,4 +98,14 @@ class MachineCollectionStateInitializationTest < StateMachinesTest
     @machines.initialize_states(@object, dynamic: true)
     assert_equal 'inactive', @object.alarm_state
   end
+
+  def test_shouldnt_force_state_given_either_as_string_or_symbol
+    @object.state = 'notparked'
+
+    @machines.initialize_states(@object, {}, { state: "parked" })
+    assert_equal 'notparked', @object.state
+
+    @machines.initialize_states(@object, {}, { "state" => "parked" })
+    assert_equal 'notparked', @object.state
+  end
 end


### PR DESCRIPTION
Earlier today we noticed an issue in one of our projects where the state
wouldn't be assigned on initialization when provided as a string (state
attributes are *usually* kept as a symbol by default)

This would fix the issue but probably bring some performance / security
penalties for projects running on older ruby versions

Ultimately this should also highlight the project is in a tough
situation. The `attributes` arg I had added to initialize_states was
to fix issues related to ativemodel / activerecord initialization but it
ends up making it very confusing if you look at this gem alone. I don't
understand most of it but the root idea of adding state machines to any
ruby object and on top of that work with the very specific and
complicated initialization process for both activerecord and activemodel
might be too much. Picking either one or another to support could makes
things simpler

// @seuros what you think? any better proper suggestion to fix this? it's far from ideal but couldn't find any other solution without adding more method overrides among the state_machines gems. Mixing regular ruby objects with activerecord initialization doesn't feel like a good idea in the first place. Perhaps we should try to make this distinction more clear.