### PR TITLE
Fixed inconsistent use of :use_transactions

### DIFF
--- a/lib/state_machines/machine_collection.rb
+++ b/lib/state_machines/machine_collection.rb
@@ -25,61 +25,72 @@ module StateMachines
 
       result = yield if block_given?
 
-      each_value do |machine| 
+      each_value do |machine|
         unless machine.dynamic_initial_state?
           force = options[:static] == :force || !attributes.keys.map(&:to_sym).include?(machine.attribute)
           machine.initialize_state(object, force: force, :to => options[:to])
         end
       end if options[:static]
-      
+
       each_value do |machine|
         machine.initialize_state(object, :force => options[:dynamic] == :force, :to => options[:to]) if machine.dynamic_initial_state?
       end if options[:dynamic]
 
       result
     end
-    
+
     # Runs one or more events in parallel on the given object.  See
     # StateMachines::InstanceMethods#fire_events for more information.
     def fire_events(object, *events)
       run_action = [true, false].include?(events.last) ? events.pop : true
-      
+
+      use_transaction = nil
+
       # Generate the transitions to run for each event
       transitions = events.collect do |event_name|
         # Find the actual event being run
         event = nil
         detect {|name, machine| event = machine.events[event_name, :qualified_name]}
-        
+
         raise(InvalidEvent.new(object, event_name)) unless event
-        
+
         # Get the transition that will be performed for the event
         unless transition = event.transition_for(object)
           event.on_failure(object)
         end
-        
+
+        # Determine use_transaction setting for this set of transitions.  If from multiple state_machines, the settings must match.
+        raise 'fire_events encountered mismatched use_configurations for multiple state_machines' if !use_transaction.nil? && use_transaction != machine.use_transaction
+        use_transaction = machine.use_transaction
+
         transition
       end.compact
-      
+
       # Run the events in parallel only if valid transitions were found for
       # all of them
       if events.length == transitions.length
-        TransitionCollection.new(transitions, :actions => run_action).perform
+        TransitionCollection.new(transitions, {use_transaction: use_transaction, actions: run_action}).perform
       else
         false
       end
     end
-    
+
     # Builds the collection of transitions for all event attributes defined on
     # the given object.  This will only include events whose machine actions
     # match the one specified.
     # 
     # These should only be fired as a result of the action being run.
     def transitions(object, action, options = {})
+      use_transaction = nil
       transitions = map do |name, machine|
         machine.events.attribute_transition_for(object, true) if machine.action == action
+
+        # Determine use_transaction setting for this set of transitions.  If from multiple state_machines, the settings must match.
+        raise 'fire_events encountered mismatched use_configurations for multiple state_machines' if !use_transaction.nil? && use_transaction != machine.use_transaction
+        use_transaction = machine.use_transaction
       end
-      
-      AttributeTransitionCollection.new(transitions.compact, options)
+
+      AttributeTransitionCollection.new(transitions.compact, {use_transaction: use_transaction}.merge(options))
     end
   end
 end

--- a/lib/state_machines/machine_collection.rb
+++ b/lib/state_machines/machine_collection.rb
@@ -44,8 +44,6 @@ module StateMachines
     def fire_events(object, *events)
       run_action = [true, false].include?(events.last) ? events.pop : true
 
-      use_transaction = nil
-
       # Generate the transitions to run for each event
       transitions = events.collect do |event_name|
         # Find the actual event being run
@@ -58,18 +56,13 @@ module StateMachines
         unless transition = event.transition_for(object)
           event.on_failure(object)
         end
-
-        # Determine use_transaction setting for this set of transitions.  If from multiple state_machines, the settings must match.
-        raise 'fire_events encountered mismatched use_configurations for multiple state_machines' if !use_transaction.nil? && use_transaction != machine.use_transaction
-        use_transaction = machine.use_transaction
-
         transition
       end.compact
 
       # Run the events in parallel only if valid transitions were found for
       # all of them
       if events.length == transitions.length
-        TransitionCollection.new(transitions, {use_transaction: use_transaction, actions: run_action}).perform
+        TransitionCollection.new(transitions, {use_transactions: resolve_use_transactions, actions: run_action}).perform
       else
         false
       end
@@ -81,16 +74,23 @@ module StateMachines
     # 
     # These should only be fired as a result of the action being run.
     def transitions(object, action, options = {})
-      use_transaction = nil
       transitions = map do |name, machine|
         machine.events.attribute_transition_for(object, true) if machine.action == action
-
-        # Determine use_transaction setting for this set of transitions.  If from multiple state_machines, the settings must match.
-        raise 'fire_events encountered mismatched use_configurations for multiple state_machines' if !use_transaction.nil? && use_transaction != machine.use_transaction
-        use_transaction = machine.use_transaction
       end
 
-      AttributeTransitionCollection.new(transitions.compact, {use_transaction: use_transaction}.merge(options))
+      AttributeTransitionCollection.new(transitions.compact, {use_transactions: resolve_use_transactions}.merge(options))
+    end
+
+    protected
+
+    def resolve_use_transactions
+      use_transactions = nil
+      each_value do |machine|
+        # Determine use_transactions setting for this set of transitions.  If from multiple state_machines, the settings must match.
+        raise 'Encountered mismatched use_transactions configurations for multiple state_machines' if !use_transactions.nil? && use_transactions != machine.use_transactions
+        use_transactions = machine.use_transactions
+      end
+      use_transactions
     end
   end
 end

--- a/lib/state_machines/transition.rb
+++ b/lib/state_machines/transition.rb
@@ -160,7 +160,7 @@ module StateMachines
       self.args = args
       
       # Run the transition
-      !!TransitionCollection.new([self], {use_transaction: machine.use_transaction, actions: run_action}).perform
+      !!TransitionCollection.new([self], {use_transactions: machine.use_transactions, actions: run_action}).perform
     end
     
     # Runs a block within a transaction for the object being transitioned.

--- a/lib/state_machines/transition.rb
+++ b/lib/state_machines/transition.rb
@@ -160,7 +160,7 @@ module StateMachines
       self.args = args
       
       # Run the transition
-      !!TransitionCollection.new([self], :actions => run_action).perform
+      !!TransitionCollection.new([self], {use_transaction: machine.use_transaction, actions: run_action}).perform
     end
     
     # Runs a block within a transaction for the object being transitioned.

--- a/lib/state_machines/transition_collection.rb
+++ b/lib/state_machines/transition_collection.rb
@@ -30,10 +30,10 @@ module StateMachines
       fail ArgumentError, 'Cannot perform multiple transitions in parallel for the same state machine attribute' if attributes.length != length
 
       options.assert_valid_keys(:actions, :after, :transaction)
-      options = {:actions => true, :after => true, :transaction => true}.merge(options)
+      options = {actions: true, after: true, use_transaction: true}.merge(options)
       @skip_actions = !options[:actions]
       @skip_after = !options[:after]
-      @use_transaction = options[:transaction]
+      @use_transaction = options[:use_transaction]
     end
     
     # Runs each of the collection's transitions in parallel.
@@ -192,7 +192,7 @@ module StateMachines
   # based events
   class AttributeTransitionCollection < TransitionCollection
     def initialize(transitions = [], options = {}) #:nodoc:
-      super(transitions, {:transaction => false, :actions => false}.merge(options))
+      super(transitions, {use_transaction: false, :actions => false}.merge(options))
     end
     
     private

--- a/lib/state_machines/transition_collection.rb
+++ b/lib/state_machines/transition_collection.rb
@@ -10,7 +10,7 @@ module StateMachines
     attr_reader :skip_after
     
     # Whether transitions should wrapped around a transaction block
-    attr_reader :use_transaction
+    attr_reader :use_transactions
     
     # Creates a new collection of transitions that can be run in parallel.  Each
     # transition *must* be for a different attribute.
@@ -29,11 +29,11 @@ module StateMachines
       attributes = map {|transition| transition.attribute}.uniq
       fail ArgumentError, 'Cannot perform multiple transitions in parallel for the same state machine attribute' if attributes.length != length
 
-      options.assert_valid_keys(:actions, :after, :transaction)
-      options = {actions: true, after: true, use_transaction: true}.merge(options)
+      options.assert_valid_keys(:actions, :after, :use_transactions)
+      options = {actions: true, after: true, use_transactions: true}.merge(options)
       @skip_actions = !options[:actions]
       @skip_after = !options[:after]
-      @use_transaction = options[:use_transaction]
+      @use_transactions = options[:use_transactions]
     end
     
     # Runs each of the collection's transitions in parallel.
@@ -177,7 +177,7 @@ module StateMachines
       # Runs a block within a transaction for the object being transitioned.  If
       # transactions are disabled, then this is a no-op.
       def within_transaction
-        if use_transaction && !empty?
+        if use_transactions && !empty?
           first.within_transaction do
             yield
             success?
@@ -192,7 +192,7 @@ module StateMachines
   # based events
   class AttributeTransitionCollection < TransitionCollection
     def initialize(transitions = [], options = {}) #:nodoc:
-      super(transitions, {use_transaction: false, :actions => false}.merge(options))
+      super(transitions, {use_transactions: false, :actions => false}.merge(options))
     end
     
     private

--- a/test/unit/transition_collection/attribute_transition_collection_by_default_test.rb
+++ b/test/unit/transition_collection/attribute_transition_collection_by_default_test.rb
@@ -14,7 +14,7 @@ class AttributeTransitionCollectionByDefaultTest < StateMachinesTest
   end
 
   def test_should_not_use_transaction
-    refute @transitions.use_transaction
+    refute @transitions.use_transactions
   end
 
   def test_should_be_empty

--- a/test/unit/transition_collection/transition_collection_by_default_test.rb
+++ b/test/unit/transition_collection/transition_collection_by_default_test.rb
@@ -14,7 +14,7 @@ class TransitionCollectionByDefaultTest < StateMachinesTest
   end
 
   def test_should_use_transaction
-    assert @transitions.use_transaction
+    assert @transitions.use_transactions
   end
 
   def test_should_be_empty

--- a/test/unit/transition_collection/transition_collection_test.rb
+++ b/test/unit/transition_collection/transition_collection_test.rb
@@ -3,7 +3,7 @@ require_relative '../../test_helper'
 class TransitionCollectionTest < StateMachinesTest
   def test_should_raise_exception_if_invalid_option_specified
     exception = assert_raises(ArgumentError) { StateMachines::TransitionCollection.new([], invalid: true) }
-    assert_equal 'Unknown key: :invalid. Valid keys are: :actions, :after, :transaction', exception.message
+    assert_equal 'Unknown key: :invalid. Valid keys are: :actions, :after, :use_transactions', exception.message
   end
 
   def test_should_raise_exception_if_multiple_transitions_for_same_attribute_specified

--- a/test/unit/transition_collection/transition_collection_with_transactions_test.rb
+++ b/test/unit/transition_collection/transition_collection_with_transactions_test.rb
@@ -21,7 +21,7 @@ class TransitionCollectionWithTransactionsTest < StateMachinesTest
     @object = @klass.new
     @transitions = StateMachines::TransitionCollection.new([
       StateMachines::Transition.new(@object, @machine, :ignite, :parked, :idling)
-    ], transaction: true)
+    ], use_transactions: true)
   end
 
   def test_should_run_before_callbacks_within_transaction

--- a/test/unit/transition_collection/transition_collection_without_transactions_test.rb
+++ b/test/unit/transition_collection/transition_collection_without_transactions_test.rb
@@ -19,7 +19,7 @@ class TransitionCollectionWithoutTransactionsTest < StateMachinesTest
     @object = @klass.new
     @transitions = StateMachines::TransitionCollection.new([
       StateMachines::Transition.new(@object, @machine, :ignite, :parked, :idling)
-    ], transaction: false)
+    ], use_transactions: false)
     @transitions.perform
   end
 


### PR DESCRIPTION
Fixed inconsistent use of `:use_transactions` (machine.rb), `:transaction` (option in transition_collection.rb), `:use_transaction` (`attr_reader` in transition_collection.rb) and standardized on `:use_transactions`.  Made `MachineCollection` and `TransitionCollection` respect the `state_machine` `:use_transactions` configuration.  Previously, the `MachineCollection` and `TransitionCollection` were operating off of hardcoded values, and ignoring the `state_machine` configuration.  Hardcoded defaults remain but are overridden if specified in the `state_machine` configuration.

In the process, added `#resolve_use_transactions` to address a corner case where homogeneous `state_machine` `:use_transactions` configurations could create indeterminate behavior.