### PR TITLE
Mimic ActiveRecord.save behavior on rollback.

### DIFF
--- a/lib/state_machines/transition_collection.rb
+++ b/lib/state_machines/transition_collection.rb
@@ -212,6 +212,7 @@ module StateMachines
             super
           rescue Exception
             rollback unless @before_run
+            @success = nil  # mimics ActiveRecord.save behavior on rollback
             raise
           end
           


### PR DESCRIPTION
This is a non-breaking change to allow state_machines to meet standard behavior of ActiveRecord.save.  Specifically: test "ActiveRecord::Base#save returns nil on a rolled-back transaction"