### PR TITLE
Fixed state machine false duplication.

### DIFF
--- a/lib/state_machines/machine.rb
+++ b/lib/state_machines/machine.rb
@@ -420,7 +420,7 @@ module StateMachines
 
         # Find an existing machine
         machine = owner_class.respond_to?(:state_machines) &&
-          (args.first && owner_class.state_machines[name] ||
+          (args.first && owner_class.state_machines[name] || !args.first &&
           owner_class.state_machines.values.first) || nil
 
         if machine

--- a/lib/state_machines/machine.rb
+++ b/lib/state_machines/machine.rb
@@ -419,7 +419,11 @@ module StateMachines
         name = args.first || :state
 
         # Find an existing machine
-        if owner_class.respond_to?(:state_machines) && machine = owner_class.state_machines[name]
+        machine = owner_class.respond_to?(:state_machines) &&
+          (args.first && owner_class.state_machines[name] ||
+          owner_class.state_machines.values.first) || nil
+
+        if machine
           # Only create a new copy if changes are being made to the machine in
           # a subclass
           if machine.owner_class != owner_class && (options.any? || block_given?)

--- a/test/files/models/driver.rb
+++ b/test/files/models/driver.rb
@@ -1,0 +1,13 @@
+require_relative 'model_base'
+
+class Driver < ModelBase
+  state_machine :status, :initial => :parked do
+    event :park do
+      transition :idling => :parked
+    end
+
+    event :ignite do
+      transition :parked => :idling
+    end
+  end
+end

--- a/test/functional/driver_default_nonstandard_test.rb
+++ b/test/functional/driver_default_nonstandard_test.rb
@@ -1,0 +1,13 @@
+require_relative '../test_helper'
+require_relative '../files/models/driver'
+
+class DriverNonstandardTest < MiniTest::Test
+  def setup
+    @driver = Driver.new
+    @events = Driver.state_machine.events
+  end
+
+  def test_should_have
+    assert_equal 1, @events.transitions_for(@driver).size
+  end
+end


### PR DESCRIPTION
Fixed case when the state machine has a name differed to default, and call to `::state_machine` method triggered next time after the find initial one.
