### PR TITLE
remove unused singleton methods from StateMachines::Integrations::Bas…

### DIFF
--- a/lib/state_machines/integrations.rb
+++ b/lib/state_machines/integrations.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module StateMachines
   # Integrations allow state machines to take advantage of features within the
   # context of a particular library.  This is currently most useful with
@@ -54,7 +52,6 @@ module StateMachines
 
       alias_method :list, :integrations
 
-
       # Attempts to find an integration that matches the given class.  This will
       # look through all of the built-in integrations under the StateMachines::Integrations
       # namespace and find one that successfully matches the class.
@@ -102,7 +99,6 @@ module StateMachines
       def find_by_name(name)
         integrations.detect { |integration| integration.integration_name == name } || raise(IntegrationNotFound.new(name))
       end
-
 
       private
 

--- a/lib/state_machines/integrations/base.rb
+++ b/lib/state_machines/integrations/base.rb
@@ -34,10 +34,8 @@ module StateMachines
 
       end
 
-      extend ClassMethods
-
       def self.included(base) #:nodoc:
-        base.class_eval { extend ClassMethods }
+        base.extend ClassMethods
       end
     end
   end

--- a/lib/state_machines/path_collection.rb
+++ b/lib/state_machines/path_collection.rb
@@ -45,7 +45,7 @@ module StateMachines
     # 
     #   paths.from_states # => [:parked, :idling, :first_gear, ...]
     def from_states
-      map {|path| path.from_states}.flatten.uniq
+      flat_map(&:from_states).uniq
     end
     
     # Lists all of the states that can be transitioned to through the paths in
@@ -55,7 +55,7 @@ module StateMachines
     # 
     #   paths.to_states # => [:idling, :first_gear, :second_gear, ...]
     def to_states
-      map {|path| path.to_states}.flatten.uniq
+      flat_map(&:to_states).uniq
     end
     
     # Lists all of the events that can be fired through the paths in this
@@ -65,7 +65,7 @@ module StateMachines
     # 
     #   paths.events  # => [:park, :ignite, :shift_up, ...]
     def events
-      map {|path| path.events}.flatten.uniq
+      flat_map(&:events).uniq
     end
     
     private

--- a/lib/state_machines/state_collection.rb
+++ b/lib/state_machines/state_collection.rb
@@ -93,7 +93,7 @@ module StateMachines
 
       machine.events.each { |event| order += event.known_states }
       order += select { |state| state.context_methods.any? }.map { |state| state.name }
-      order += keys(:name) - machine.callbacks.values.flatten.map { |callback| callback.known_states }.flatten
+      order += keys(:name) - machine.callbacks.values.flatten.flat_map(&:known_states)
       order += keys(:name)
 
       order.uniq!


### PR DESCRIPTION
…e; simplify included hook since Object#extend is public method