### PR TITLE
Fix states being evaluated with wrong `owner_class` context

### DIFF
--- a/lib/state_machines/state.rb
+++ b/lib/state_machines/state.rb
@@ -10,7 +10,7 @@ module StateMachines
   class State
 
     # The state machine for which this state is defined
-    attr_accessor :machine
+    attr_reader :machine
 
     # The unique identifier for the state used in event and callback definitions
     attr_reader :name
@@ -83,6 +83,11 @@ module StateMachines
     # across different machines.
     def initialize_copy(orig) #:nodoc:
       super
+      @context = StateContext.new(self)
+    end
+
+    def machine=(machine)
+      @machine = machine
       @context = StateContext.new(self)
     end
 

--- a/test/files/models/motorcycle.rb
+++ b/test/files/models/motorcycle.rb
@@ -1,11 +1,16 @@
 require_relative '../../files/models/vehicle'
 
 class Motorcycle < Vehicle
+  def self.example_class_method(args={})
+  end
+
   state_machine initial: :idling do
     state :first_gear do
       def decibels
         1.0
       end
+
+      example_class_method
     end
   end
 end

--- a/test/functional/motorcycle_test.rb
+++ b/test/functional/motorcycle_test.rb
@@ -43,4 +43,10 @@ class MotorcycleTest < MiniTest::Test
     @motorcycle.shift_up
     assert_equal 1.0, @motorcycle.decibels
   end
+
+  def test_should_use_decibels_defined_in_state
+    vehicle = Vehicle.new
+    @motorcycle.shift_up
+    assert_equal 0.0, vehicle.decibels
+  end
 end


### PR DESCRIPTION
When a sub-class clones a new copy of the machine the states get updated but the cached `StateContext` was still pointing to the old machine instance. Meaning that each `state` rule gets evaluated in the context of the parent class.

We first noticed this with ActiveRecord objects using single table inheritance. Adding validation rules in `state`s on the sub-class would cause the parent class to also apply those validations.

The added test case actually passes without the fix, but I can’t quite figure out why. Something to do with the _default definee_ for `def` in the context of a `class_eval`, I think.

In any case, `example_class_method` will cause an undefined method error if it is called on `Vehicle`, but executes correctly on `Motorcycle` with the fix applied.