### PR TITLE
Support prepend module

### DIFF
--- a/lib/state_machines/machine.rb
+++ b/lib/state_machines/machine.rb
@@ -2052,7 +2052,7 @@ module StateMachines
     def owner_class_ancestor_has_method?(scope, method)
       return false unless owner_class_has_method?(scope, method)
 
-      superclasses = owner_class.ancestors[1..-1].select { |ancestor| ancestor.is_a?(Class) }
+      superclasses = owner_class.ancestors.select { |ancestor| ancestor.is_a?(Class) }[1..-1]
 
       if scope == :class
         current = owner_class.singleton_class

--- a/test/unit/machine/machine_with_action_defined_in_prepended_module_test.rb
+++ b/test/unit/machine/machine_with_action_defined_in_prepended_module_test.rb
@@ -1,6 +1,6 @@
 require_relative '../../test_helper'
 
-class MachineWithActionDefinedInIncludedModuleTest < StateMachinesTest
+class MachineWithActionDefinedInPrependedModuleTest < StateMachinesTest
   def setup
     @mod = mod = Module.new do
       def save
@@ -8,7 +8,7 @@ class MachineWithActionDefinedInIncludedModuleTest < StateMachinesTest
     end
 
     @klass = Class.new do
-      include mod
+      prepend mod
 
       def bar
       end
@@ -34,8 +34,8 @@ class MachineWithActionDefinedInIncludedModuleTest < StateMachinesTest
     assert @object.respond_to?(:state_event_transition=, true)
   end
 
-  def test_should_define_action
-    assert @klass.ancestors.any? { |ancestor| ![@klass, @mod].include?(ancestor) && ancestor.method_defined?(:save) }
+  def test_should_not_define_action
+    assert @klass.ancestors.none? { |ancestor| ![@klass, @mod].include?(ancestor) && ancestor.method_defined?(:save) }
   end
 
   def test_should_keep_action_public
@@ -43,7 +43,7 @@ class MachineWithActionDefinedInIncludedModuleTest < StateMachinesTest
   end
 
   def test_should_mark_action_hook_as_defined
-    assert @machine.action_hook?
+    refute @machine.action_hook?
   end
 
   def test_should_owner_class_ancestor_has_method_return_nil


### PR DESCRIPTION
`owner_class_ancestor_has_method?` search if method is already defined in one of ancestors list class.

The method searches through the list of ancestors filtering out only the classes after excluding the first
element of the list.
If a module is prepended exclude the first element
of the list( the prepended module) and then the first class return
the owner_class.

Reverse the flow so that exclude the first element after filtering out only the classes.
