### PR TITLE
Optimize Integrations::Base::ClassMethods#matches?

### DIFF
--- a/lib/state_machines/integrations.rb
+++ b/lib/state_machines/integrations.rb
@@ -86,7 +86,7 @@ module StateMachines
       # == Examples
       #
       #   StateMachines::Integrations.match_ancestors([])                    # => nil
-      #   StateMachines::Integrations.match_ancestors(['ActiveRecord::Base']) # => StateMachines::Integrations::ActiveModel
+      #   StateMachines::Integrations.match_ancestors([ActiveRecord::Base]) # => StateMachines::Integrations::ActiveModel
       def match_ancestors(ancestors)
         integrations.detect { |integration| integration.matches_ancestors?(ancestors) }
       end

--- a/lib/state_machines/integrations/base.rb
+++ b/lib/state_machines/integrations/base.rb
@@ -24,14 +24,13 @@ module StateMachines
 
         # Whether the integration should be used for the given class.
         def matches?(klass)
-          matches_ancestors?(klass.ancestors.map { |ancestor| ancestor.name })
+          matching_ancestors.any? { |ancestor| klass <= ancestor }
         end
 
         # Whether the integration should be used for the given list of ancestors.
         def matches_ancestors?(ancestors)
           (ancestors & matching_ancestors).any?
         end
-
       end
 
       extend ClassMethods

--- a/test/files/integrations/vehicle.rb
+++ b/test/files/integrations/vehicle.rb
@@ -2,6 +2,6 @@ module VehicleIntegration
   include StateMachines::Integrations::Base
 
   def self.matching_ancestors
-    ['Vehicle']
+    [Vehicle]
   end
 end

--- a/test/unit/integrations/integration_matcher_test.rb
+++ b/test/unit/integrations/integration_matcher_test.rb
@@ -17,11 +17,13 @@ class IntegrationMatcherTest < StateMachinesTest
   end
 
   def test_should_return_nil_if_no_match_found_with_ancestors
-    assert_nil StateMachines::Integrations.match_ancestors(['Fake'])
+    fake = Class.new
+    assert_nil StateMachines::Integrations.match_ancestors([fake])
   end
 
   def test_should_return_integration_class_if_match_found_with_ancestors
+    fake = Class.new
     StateMachines::Integrations.register(VehicleIntegration)
-    assert_equal VehicleIntegration, StateMachines::Integrations.match_ancestors(['Fake', 'Vehicle'])
+    assert_equal VehicleIntegration, StateMachines::Integrations.match_ancestors([fake, Vehicle])
   end
 end

--- a/test/unit/machine/machine_with_custom_integration_test.rb
+++ b/test/unit/machine/machine_with_custom_integration_test.rb
@@ -6,7 +6,7 @@ class MachineWithCustomIntegrationTest < StateMachinesTest
     include StateMachines::Integrations::Base
 
     def self.matching_ancestors
-      ['Vehicle']
+      [Vehicle]
     end
   end
 
@@ -65,7 +65,7 @@ class MachineWithCustomIntegrationTest < StateMachinesTest
     MachineWithCustomIntegrationTest::Custom.class_eval do
       class << self; remove_method :matching_ancestors; end
       def self.matching_ancestors
-        ['Vehicle']
+        [Vehicle]
       end
     end
   end


### PR DESCRIPTION
Followup to: https://github.com/state-machines/state_machines/pull/50

I was investigating into our app boot time today, and I found something interesting:

```
==================================
  Mode: wall(1000)
  Samples: 22 (21.43% miss rate)
  GC: 2 (9.09%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
         6  (27.3%)           5  (22.7%)     StateMachines::Machine#owner_class_ancestor_has_method?
         5  (22.7%)           5  (22.7%)     block in StateMachines::Integrations::Base::ClassMethods#matches?
         1   (4.5%)           1   (4.5%)     block in ActiveSupport::Dependencies#search_for_file
         1   (4.5%)           1   (4.5%)     Hash#assert_valid_keys
         1   (4.5%)           1   (4.5%)     StateMachines::NodeCollection#value
         1   (4.5%)           1   (4.5%)     StateMachines::Machine#define_helper
         1   (4.5%)           1   (4.5%)     ActiveRecord::DynamicMatchers#respond_to?
         1   (4.5%)           1   (4.5%)     block in StateMachines::Machine#owner_class_ancestor_has_method?
         1   (4.5%)           1   (4.5%)     ActiveSupport::Callbacks::ClassMethods#get_callbacks
         1   (4.5%)           1   (4.5%)     ActiveSupport::Concern#append_features
```

Turns out looking out for ancestors by name is very slow. If we instead use `Module#<=` it basically disapears from the profile.

One problem though, this is a breaking change. All integrations would have to be updated.

One possiblity would be to `constantize` those names and issue a warnings, but I'm not sure if it's worth it.

@seuros @rafaelfranca thoughts?