### PR TITLE
pass event args to after_failure callbacks

### DIFF
--- a/lib/state_machines/event.rb
+++ b/lib/state_machines/event.rb
@@ -154,18 +154,20 @@ module StateMachines
       if transition = transition_for(object)
         transition.perform(*args)
       else
-        on_failure(object)
+        on_failure(object, *args)
         false
       end
     end
 
     # Marks the object as invalid and runs any failure callbacks associated with
     # this event.  This should get called anytime this event fails to transition.
-    def on_failure(object)
+    def on_failure(object, *args)
       state = machine.states.match!(object)
       machine.invalidate(object, :state, :invalid_transition, [[:event, human_name(object.class)], [:state, state.human_name(object.class)]])
 
-      Transition.new(object, machine, name, state.name, state.name).run_callbacks(:before => false)
+      transition = Transition.new(object, machine, name, state.name, state.name)
+      transition.args = args if args.any?
+      transition.run_callbacks(:before => false)
     end
 
     # Resets back to the initial state of the event, with no branches / known

--- a/test/unit/event/event_on_failure_test.rb
+++ b/test/unit/event/event_on_failure_test.rb
@@ -36,6 +36,19 @@ class EventOnFailureTest < StateMachinesTest
     assert_equal :ignite, transition.event
     assert_equal :parked, transition.from_name
     assert_equal :parked, transition.to_name
+    assert_equal [], transition.args
+  end
+
+  def test_should_pass_args_to_failure_callbacks
+    callback_args = nil
+    @machine.after_failure { |*args| callback_args = args }
+
+    @event.fire(@object, foo: 'bar')
+
+    object, transition = callback_args
+    assert_equal @object, object
+    refute_nil transition
+    assert_equal [{foo: 'bar'}], transition.args  
   end
 
   def teardown


### PR DESCRIPTION
When passing arguments to an event, the `after_failure` callback does not include the arguments