### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: ruby
-sudo: false
 script: "bundle exec rake"
 cache: bundler
 rvm:
   - 2.1
   - 2.0.0
   - 2.2
-  - 2.3.4
-  - 2.4.1
-  - 2.5.3
-  - 2.6.0
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - jruby
   - rbx-2
 matrix:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known