### PR TITLE
docs: fix example for the `same` helper method

### DIFF
--- a/lib/state_machines/matcher_helpers.rb
+++ b/lib/state_machines/matcher_helpers.rb
@@ -46,7 +46,7 @@ module StateMachines
     # In the above example, +same+ will match whichever the from state is.  In
     # the case of the +ignite+ event, it is essential the same as the following:
     # 
-    #   transition :parked => :parked, :first_gear => :first_gear
+    #   transition :idling => :idling, :first_gear => :first_gear
     def same
       LoopbackMatcher.instance
     end


### PR DESCRIPTION
It looks like we have a mismatch in our current example:

https://github.com/state-machines/state_machines/blob/d25ae3dfa3a66a2ba1006debf7a4a9cb3aedc327/lib/state_machines/matcher_helpers.rb#L36-L49

I can't see the `:parked` state anywhere in the example. It seems we wanted to have `:idling` instead of `:parked`, doesn't it?