### PR TITLE
Add transition & branch debug information

### DIFF
--- a/lib/state_machines/branch.rb
+++ b/lib/state_machines/branch.rb
@@ -26,11 +26,17 @@ module StateMachines
     # * +to+ / +except_to+
     attr_reader :known_states
 
+    # Debug information about where the branch was defined.
+    attr_reader :defined_in
+
     # Creates a new branch
     def initialize(options = {}) #:nodoc:
       # Build conditionals
       @if_condition = options.delete(:if)
       @unless_condition = options.delete(:unless)
+
+      # Build debug information
+      @defined_in = options.delete(:defined_in)
 
       # Build event requirement
       @event_requirement = build_matcher(options, :on, :except_on)

--- a/lib/state_machines/event.rb
+++ b/lib/state_machines/event.rb
@@ -91,6 +91,9 @@ module StateMachines
       # requirements
       options.assert_valid_keys(:from, :to, :except_from, :except_to, :if, :unless) if (options.keys - [:from, :to, :on, :except_from, :except_to, :except_on, :if, :unless]).empty?
 
+      # Inject useful debug information to be used in runtime
+      options[:defined_in] = caller[0]
+
       branches << branch = Branch.new(options.merge(on: name))
       @known_states |= branch.known_states
       branch
@@ -134,7 +137,7 @@ module StateMachines
                  match[:to].filter(values).first
                end
 
-          return Transition.new(object, machine, name, from, to, !custom_from_state)
+          return Transition.new(object, machine, name, from, to, !custom_from_state, branch.defined_in)
         end
       end
 

--- a/lib/state_machines/transition.rb
+++ b/lib/state_machines/transition.rb
@@ -28,6 +28,9 @@ module StateMachines
     # Whether the transition is only existing temporarily for the object
     attr_writer :transient
 
+    # Debug information about where the transition was defined.
+    attr_reader :defined_in
+
     # Determines whether the current ruby implementation supports pausing and
     # resuming transitions
     def self.pause_supported?
@@ -35,7 +38,7 @@ module StateMachines
     end
 
     # Creates a new, specific transition
-    def initialize(object, machine, event, from_name, to_name, read_state = true) #:nodoc:
+    def initialize(object, machine, event, from_name, to_name, read_state = true, defined_in = nil) #:nodoc:
       @object = object
       @machine = machine
       @args = []
@@ -47,6 +50,8 @@ module StateMachines
       @from = read_state ? machine.read(object, :state) : @from_state.value
       @to_state = machine.states.fetch(to_name)
       @to = @to_state.value
+
+      @defined_in = defined_in
 
       reset
     end

--- a/test/unit/branch/branch_test.rb
+++ b/test/unit/branch/branch_test.rb
@@ -21,6 +21,15 @@ class BranchTest < StateMachinesTest
     assert_equal 1, @branch.state_requirements.length
   end
 
+  def test_should_not_have_a_defined_in
+    assert_nil(@branch.defined_in)
+  end
+
+  def test_should_have_a_defined_in
+    @branch = StateMachines::Branch.new(from: :parked, to: :idling, defined_in: "")
+    assert_equal("", @branch.defined_in)
+  end
+
   def test_should_raise_an_exception_if_invalid_match_option_specified
     exception = assert_raises(ArgumentError) { @branch.match(Object.new, invalid: true) }
     assert_equal 'Unknown key: :invalid. Valid keys are: :from, :to, :on, :guard', exception.message

--- a/test/unit/event/event_transitions_test.rb
+++ b/test/unit/event/event_transitions_test.rb
@@ -54,6 +54,11 @@ class EventTransitionsTest < StateMachinesTest
     assert @event.transition(parked: [:parked, :idling])
   end
 
+  def test_should_have_a_backtrace_defined
+    branch = @event.transition(to: :idling)
+    assert_instance_of(String, branch.defined_in)
+  end
+
   def test_should_have_transitions
     branch = @event.transition(to: :idling)
     assert_equal [branch], @event.branches

--- a/test/unit/transition/transition_defined_in_test.rb
+++ b/test/unit/transition/transition_defined_in_test.rb
@@ -1,0 +1,21 @@
+require_relative '../../test_helper'
+
+class TransitionDefinedTest < StateMachinesTest
+  def setup
+    @klass = Class.new
+
+    @machine = StateMachines::Machine.new(@klass)
+    @machine.state :parked, :idling
+    @machine.event :ignite
+
+    @caller = caller[0]
+
+    @object = @klass.new
+    @object.state = 'parked'
+    @transition = StateMachines::Transition.new(@object, @machine, :ignite, :parked, :idling, true, @caller)
+  end
+
+  def test_defined_in_should_set
+    assert @transition.defined_in == @caller
+  end
+end


### PR DESCRIPTION
Enrich information about the where the transition executed was defined for easier traceability in runtime.

This will enable me and my team to know where the transition was called during runtime, in order to provide better metrics/logs.

**NOTE:** Tests added & nothing broke during the implementation.

Snippet of our current usage:

```ruby
state_machine initial: created do 
    event :finish do
		transition created: :finished ## <- The objective is for the log to point to this line.
    end

	before_transition do |_, transition|
        puts "#{transition.event}: Moving from #{transition.from} to #{transition.to} (defined_in: #{transition.defined_in})"
	end
end
```