### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/engines.yml
+++ b/.github/workflows/engines.yml
@@ -14,7 +14,7 @@ jobs:
         ruby-version: ['jruby', 'truffleruby']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/test/unit/eval_helper/eval_helpers_symbol_tainted_method_test.rb
+++ b/test/unit/eval_helper/eval_helpers_symbol_tainted_method_test.rb
@@ -1,18 +1,21 @@
 require_relative '../../test_helper'
 require_relative '../../unit/eval_helper/eval_helpers_base_test'
 
-class EvalHelpersSymbolTaintedMethodTest < EvalHelpersBaseTest
-  def setup
-    class << (@object = Object.new)
-      def callback
-        true
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2")
+
+  class EvalHelpersSymbolTaintedMethodTest < EvalHelpersBaseTest
+    def setup
+      class << (@object = Object.new)
+        def callback
+          true
+        end
+
+        taint
       end
-
-      taint
     end
-  end
 
-  def test_should_not_raise_security_error
-    evaluate_method(@object, :callback, 1, 2, 3)
+    def test_should_not_raise_security_error
+      evaluate_method(@object, :callback, 1, 2, 3)
+    end
   end
 end


### PR DESCRIPTION
Also updates the checkout action version constraint to v3 to eliminate a Node 12 warning in actions.

To get the specs running green I had to conditionally disable the `taint` test, since that method no longer exists in Ruby 3.2+

Runs green on my fork.