### PR TITLE
Attempting to solve the Ruby 2.7 Kwarg warnings/3.0 issue with kwargs in unsafe/bang methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/state_machines/event.rb
+++ b/lib/state_machines/event.rb
@@ -224,7 +224,15 @@ module StateMachines
 
       # Fires the event, raising an exception if it fails
       machine.define_helper(:instance, "#{qualified_name}!") do |machine, object, *args|
-        object.send(qualified_name, *args) || raise(StateMachines::InvalidTransition.new(object, machine, name))
+        kwargs = {}
+        pargs = []
+
+        if args.any?
+          kwargs, pargs = args.partition { _1.is_a?(Hash) }
+          kwargs = kwargs.any? ? kwargs.inject(:merge) : {}
+        end
+
+        object.send(qualified_name, *pargs, **kwargs) || raise(StateMachines::InvalidTransition.new(object, machine, name))
       end
     end
   end

--- a/lib/state_machines/event.rb
+++ b/lib/state_machines/event.rb
@@ -224,16 +224,32 @@ module StateMachines
 
       # Fires the event, raising an exception if it fails
       machine.define_helper(:instance, "#{qualified_name}!") do |machine, object, *args|
-        kwargs = {}
-        pargs = []
+        kwargs, pargs = split_arguments(args)
 
-        if args.any?
-          kwargs, pargs = args.partition { _1.is_a?(Hash) }
-          kwargs = kwargs.any? ? kwargs.inject(:merge) : {}
+        if kwargs.any?
+          object.send(qualified_name, *pargs, **kwargs) || raise_exception(object, machine, name)
+        else
+          object.send(qualified_name, *args) || raise_exception(object, machine, name)
         end
-
-        object.send(qualified_name, *pargs, **kwargs) || raise(StateMachines::InvalidTransition.new(object, machine, name))
       end
+    end
+
+  private
+
+    def split_arguments(arguments)
+      kwargs = {}
+      pargs = []
+
+      if arguments.any?
+        kwargs, pargs = arguments.partition { _1.is_a?(Hash) }
+        kwargs = kwargs.any? ? kwargs.inject(:merge) : {}
+      end
+
+      [kwargs, pargs]
+    end
+
+    def raise_exception(object, machine, name)
+      raise(StateMachines::InvalidTransition.new(object, machine, name))
     end
   end
 end

--- a/test/files/models/hybrid_car.rb
+++ b/test/files/models/hybrid_car.rb
@@ -1,0 +1,44 @@
+require_relative '../../files/models/vehicle'
+
+class HybridCar < Vehicle
+  attr_accessor :propulsion_mode, :driving_profile, :target_year
+
+  state_machine :propulsion_mode, initial: :gas do
+    event :go_green do
+      transition electric: :electric
+      transition flux_capacitor: :electric
+      transition gas: :electric
+    end
+
+    event :go_gas do
+      transition electric: :gas
+      transition flux_capacitor: :gas
+      transition gas: :gas
+    end
+
+    event :go_back_in_time do
+      transition electric: :flux_capacitor
+      transition flux_capacitor: :flux_capacitor
+      transition gas: :flux_capacitor
+    end
+  end
+
+  def go_green(driving_profile = nil)
+    self.driving_profile = driving_profile if driving_profile
+
+    super()
+  end
+
+  def go_gas(driving_profile:)
+    self.driving_profile = driving_profile
+
+    super()
+  end
+
+  def go_back_in_time(target_year, driving_profile:)
+    self.target_year = target_year
+    self.driving_profile = driving_profile
+
+    super()
+  end
+end

--- a/test/functional/hybrid_car_test.rb
+++ b/test/functional/hybrid_car_test.rb
@@ -1,0 +1,52 @@
+require_relative '../test_helper'
+require_relative '../files/models/hybrid_car'
+
+class HybridCarTest < MiniTest::Test
+  def setup
+    @hybrid_car = HybridCar.new
+  end
+
+  def test_should_accept_positional_argument
+    assert @hybrid_car.go_green(:eco)
+    assert @hybrid_car.electric?
+    assert_equal @hybrid_car.propulsion_mode, 'electric'
+    assert_equal @hybrid_car.driving_profile, :eco
+  end
+
+  def test_should_accept_keyword_argument
+    assert @hybrid_car.go_gas(driving_profile: :sport)
+    assert @hybrid_car.gas?
+    assert_equal @hybrid_car.propulsion_mode, 'gas'
+    assert_equal @hybrid_car.driving_profile, :sport
+  end
+
+  def test_should_accept_positional_and_keyword_arguments
+    assert @hybrid_car.go_back_in_time(1995, driving_profile: '1.21 gigawatts')
+    assert @hybrid_car.flux_capacitor?
+    assert_equal @hybrid_car.target_year, 1995
+    assert_equal @hybrid_car.propulsion_mode, 'flux_capacitor'
+    assert_equal @hybrid_car.driving_profile, '1.21 gigawatts'
+  end
+
+  def test_should_accept_positional_arguments_in_unsafe_method
+    assert @hybrid_car.go_green!(:eco)
+    assert @hybrid_car.electric?
+    assert_equal @hybrid_car.propulsion_mode, 'electric'
+    assert_equal @hybrid_car.driving_profile, :eco
+  end
+
+  def test_should_accept_keyword_argument_in_unsafe_method
+    assert @hybrid_car.go_gas!(driving_profile: :sport)
+    assert @hybrid_car.gas?
+    assert_equal @hybrid_car.propulsion_mode, 'gas'
+    assert_equal @hybrid_car.driving_profile, :sport
+  end
+
+  def test_should_accept_positional_and_keyword_arguments_in_unsafe_method
+    assert @hybrid_car.go_back_in_time!(1995, driving_profile: '1.21 gigawatts')
+    assert @hybrid_car.flux_capacitor?
+    assert_equal @hybrid_car.target_year, 1995
+    assert_equal @hybrid_car.propulsion_mode, 'flux_capacitor'
+    assert_equal @hybrid_car.driving_profile, '1.21 gigawatts'
+  end
+end


### PR DESCRIPTION
Some time ago I opened this issue: https://github.com/state-machines/state_machines/issues/82

It was closed because everything seemed to be fine.

However https://github.com/state-machines/state_machines/issues/82#issuecomment-1569076464 by @jmanian made me think about the issue again. Instead of providing a test rails application that triggers the problem as I did when I opened the issue, this time I thought of getting inside the gem and try to solve it.

So I created some functional specs (see [HybridCar](https://github.com/julitrows/state_machines/blob/2ff8e4e53ca9cfd250d635dc33714cf6c2a0baf3/test/files/models/hybrid_car.rb) and [HybridCarTest](https://github.com/julitrows/state_machines/blob/2ff8e4e53ca9cfd250d635dc33714cf6c2a0baf3/test/functional/hybrid_car_test.rb)) that would reflect the different ways of using positional and keyword arguments in bang methods, and see what happened.

In Ruby 2.7, I would get the Warnings of Doom™ when running the specs that use bang methods and keyword arguments:

- `test_should_accept_keyword_argument_in_unsafe_method`
- `test_should_accept_positional_and_keyword_arguments_in_unsafe_method`

```text
/<my_path>/state_machines/lib/state_machines/event.rb:227: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/<my_path>/state_machines/test/files/models/hybrid_car.rb:32: warning: The called method `go_gas' is defined here
/<my_path>/state_machines/lib/state_machines/event.rb:227: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/<my_path>/state_machines/test/files/models/hybrid_car.rb:38: warning: The called method `go_back_in_time' is defined here
```

And in Ruby 3.2.2 I would get straight errors:

```text
ERROR HybridCarTest#test_should_accept_keyword_argument_in_unsafe_method (0.03s)
Minitest::UnexpectedError:         ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: driving_profile)
            /<my_path>/state_machines/test/files/models/hybrid_car.rb:31:in `go_gas'
            /<my_path>/state_machines/lib/state_machines/event.rb:227:in `block in add_actions'
            /<my_path>/state_machines/lib/state_machines/machine.rb:729:in `block (2 levels) in define_helper'
            /<my_path>/state_machines/test/functional/hybrid_car_test.rb:39:in `test_should_accept_keyword_argument_in_unsafe_method'

ERROR HybridCarTest#test_should_accept_positional_and_keyword_arguments_in_unsafe_method (0.06s)
Minitest::UnexpectedError:         ArgumentError: wrong number of arguments (given 2, expected 1; required keyword: driving_profile)
            /<my_path>/state_machines/test/files/models/hybrid_car.rb:37:in `go_back_in_time'
            /<my_path>/state_machines/lib/state_machines/event.rb:227:in `block in add_actions'
            /<my_path>/state_machines/lib/state_machines/machine.rb:729:in `block (2 levels) in define_helper'
            /<my_path>/state_machines/test/functional/hybrid_car_test.rb:46:in `test_should_accept_positional_and_keyword_arguments_in_unsafe_method'
```

So there's a breaking issue here.

In 746d5444cc780f5190d50af545ad3151b2a29804 I attempted a basic splitting of the arguments and do the call.

This solved the ERRORS above, but made another test fail:

```
FAIL VehicleUnsavedTest#test_should_allow_ignite_bang_with_skipped_action (0.04s)
        Expected false to be truthy.
        /<my_path>/state_machines/test/functional/vehicle_unsaved_test.rb:121:in `test_should_allow_ignite_bang_with_skipped_action'
```

By looking `machine.rb` and searching for `skip` and `action` I learned there's a somewhat obscure feature in which if you pass a boolean as last argument to an event method call, that boolean is used to determine if the `action` defined in the `state_machine` opening statement gets invoked or not.

I could not find in the code where this was happening (my metaruby reading is not that good), so I thought of preserving that last boolean argument. In the end, what I did was, if I could determine that there were no kwargs passed, I would just do the original call, instead of the one with positional and keyword arguments separated.

This makes all the tests pass.

I've got some questions tho:

1. Should the treatment I've given to that helper definition be applied to every other `machine.define_helper` call in the event.rb file? There are no other warnings under 2.7, but that might just be that there is no sufficient tests trying different parg/kwarg combinations.
2. If so, should this treatment happen in `Machine#define_helper` instead?


Thanks