### PR TITLE
feat: Drop support to ruby prior 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Copyright (c) 2006-2012 Aaron Pfeifer
-Copyright (c) 2014-2021 Abdelkader Boudih
+Copyright (c) 2014-2023 Abdelkader Boudih
 
 MIT License
 

--- a/state_machines.gemspec
+++ b/state_machines.gemspec
@@ -1,5 +1,3 @@
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require_relative 'lib/state_machines/version'
 
 Gem::Specification.new do |spec|
@@ -12,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/state-machines/state_machines'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version     = '>= 2.6.8'
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.required_ruby_version     = '>= 3.0.0'
+  spec.files         = Dir.glob('{lib}/**/*') + %w(LICENSE.txt README.md)
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '>= 1.7.6'


### PR DESCRIPTION
This will allow us to use new ruby syntax exclusively

I will release this version after merging #94

cc @julitrows