### PR TITLE
Passing event kwargs to guards option

### DIFF
--- a/lib/state_machines/branch.rb
+++ b/lib/state_machines/branch.rb
@@ -111,10 +111,10 @@ module StateMachines
     #
     #   branch.match(object, :on => :ignite)  # => {:to => ..., :from => ..., :on => ...}
     #   branch.match(object, :on => :park)    # => nil
-    def match(object, query = {})
+    def match(object, query = {}, **kwargs)
       query.assert_valid_keys(:from, :to, :on, :guard)
 
-      if (match = match_query(query)) && matches_conditions?(object, query)
+      if (match = match_query(query)) && matches_conditions?(object, query, **kwargs)
         match
       end
     end
@@ -176,9 +176,9 @@ module StateMachines
 
     # Verifies that the conditionals for this branch evaluate to true for the
     # given object
-    def matches_conditions?(object, query)
+    def matches_conditions?(object, query, **kwargs)
       query[:guard] == false ||
-      Array(if_condition).all? { |condition| evaluate_method(object, condition) } &&
+      Array(if_condition).all? { |condition| evaluate_method(object, condition, **kwargs) } &&
       !Array(unless_condition).any? { |condition| evaluate_method(object, condition) }
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ end
 require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new]
 
-class StateMachinesTest < MiniTest::Test
+class StateMachinesTest < Minitest::Test
   def before_setup
     super
     StateMachines::Integrations.reset

--- a/test/unit/branch/branch_test.rb
+++ b/test/unit/branch/branch_test.rb
@@ -22,7 +22,7 @@ class BranchTest < StateMachinesTest
   end
 
   def test_should_raise_an_exception_if_invalid_match_option_specified
-    exception = assert_raises(ArgumentError) { @branch.match(Object.new, invalid: true) }
+    exception = assert_raises(ArgumentError) { @branch.match(Object.new, {invalid: true}) }
     assert_equal 'Unknown key: :invalid. Valid keys are: :from, :to, :on, :guard', exception.message
   end
 end

--- a/test/unit/branch/branch_with_different_requirements_test.rb
+++ b/test/unit/branch/branch_with_different_requirements_test.rb
@@ -27,7 +27,7 @@ class BranchWithDifferentRequirementsTest < StateMachinesTest
   end
 
   def test_should_be_nil_if_unmatched
-    assert_nil @branch.match(@object, from: :parked, to: :idling, on: :park)
+    assert_nil @branch.match(@object, {from: :parked, to: :idling, on: :park})
   end
 
   def test_should_include_all_known_states

--- a/test/unit/event/event_on_failure_test.rb
+++ b/test/unit/event/event_on_failure_test.rb
@@ -43,12 +43,12 @@ class EventOnFailureTest < StateMachinesTest
     callback_args = nil
     @machine.after_failure { |*args| callback_args = args }
 
-    @event.fire(@object, foo: 'bar')
+    @event.fire(@object, {foo: 'bar'})
 
     object, transition = callback_args
     assert_equal @object, object
     refute_nil transition
-    assert_equal [{foo: 'bar'}], transition.args  
+    assert_equal [{foo: 'bar'}], transition.args
   end
 
   def teardown


### PR DESCRIPTION
Add passing kwargs from event to guard 

```ruby
class Vehicle
  state_machine :state, initial: :parked do
    ...
    event :crash do
      transition all - [:parked, :stalled] => :stalled, if: ->(vehicle, kwargs) {kwargs[:arg] == true} # kwargs from event fire
    end
  end
end

vehicle = Vehicle.new
vehicle.crash(arg: false) # false
```

