### PR TITLE
Replace old MiniTest namespace by Minitest

### DIFF
--- a/test/functional/auto_shop_available_test.rb
+++ b/test/functional/auto_shop_available_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/auto_shop'
 
-class AutoShopAvailableTest < MiniTest::Test
+class AutoShopAvailableTest < Minitest::Test
   def setup
     @auto_shop = AutoShop.new
   end

--- a/test/functional/auto_shop_busy_test.rb
+++ b/test/functional/auto_shop_busy_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/auto_shop'
 
-class AutoShopBusyTest < MiniTest::Test
+class AutoShopBusyTest < Minitest::Test
   def setup
     @auto_shop = AutoShop.new
     @auto_shop.tow_vehicle

--- a/test/functional/car_backing_up_test.rb
+++ b/test/functional/car_backing_up_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/car'
 
-class CarBackingUpTest < MiniTest::Test
+class CarBackingUpTest < Minitest::Test
   def setup
     @car = Car.new
     @car.reverse

--- a/test/functional/car_test.rb
+++ b/test/functional/car_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/car'
 
-class CarTest < MiniTest::Test
+class CarTest < Minitest::Test
   def setup
     @car = Car.new
   end

--- a/test/functional/driver_default_nonstandard_test.rb
+++ b/test/functional/driver_default_nonstandard_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/driver'
 
-class DriverNonstandardTest < MiniTest::Test
+class DriverNonstandardTest < Minitest::Test
   def setup
     @driver = Driver.new
     @events = Driver.state_machine.events

--- a/test/functional/hybrid_car_test.rb
+++ b/test/functional/hybrid_car_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/hybrid_car'
 
-class HybridCarTest < MiniTest::Test
+class HybridCarTest < Minitest::Test
   def setup
     @hybrid_car = HybridCar.new
   end

--- a/test/functional/motorcycle_test.rb
+++ b/test/functional/motorcycle_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/motorcycle'
 
-class MotorcycleTest < MiniTest::Test
+class MotorcycleTest < Minitest::Test
   def setup
     @motorcycle = Motorcycle.new
   end

--- a/test/functional/traffic_light_caution_test.rb
+++ b/test/functional/traffic_light_caution_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/traffic_light'
 
-class TrafficLightCautionTest < MiniTest::Test
+class TrafficLightCautionTest < Minitest::Test
   def setup
     @light = TrafficLight.new
     @light.state = 'caution'

--- a/test/functional/traffic_light_proceed_test.rb
+++ b/test/functional/traffic_light_proceed_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/traffic_light'
 
-class TrafficLightProceedTest < MiniTest::Test
+class TrafficLightProceedTest < Minitest::Test
   def setup
     @light = TrafficLight.new
     @light.state = 'proceed'

--- a/test/functional/traffic_light_stop_test.rb
+++ b/test/functional/traffic_light_stop_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/traffic_light'
 
-class TrafficLightStopTest < MiniTest::Test
+class TrafficLightStopTest < Minitest::Test
   def setup
     @light = TrafficLight.new
     @light.state = 'stop'

--- a/test/functional/vehicle_first_gear_test.rb
+++ b/test/functional/vehicle_first_gear_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleFirstGearTest < MiniTest::Test
+class VehicleFirstGearTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.ignite

--- a/test/functional/vehicle_idling_test.rb
+++ b/test/functional/vehicle_idling_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleIdlingTest < MiniTest::Test
+class VehicleIdlingTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.ignite

--- a/test/functional/vehicle_locked_test.rb
+++ b/test/functional/vehicle_locked_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleLockedTest < MiniTest::Test
+class VehicleLockedTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.state = 'locked'

--- a/test/functional/vehicle_parked_test.rb
+++ b/test/functional/vehicle_parked_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleParkedTest < MiniTest::Test
+class VehicleParkedTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
   end

--- a/test/functional/vehicle_repaired_test.rb
+++ b/test/functional/vehicle_repaired_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleRepairedTest < MiniTest::Test
+class VehicleRepairedTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.ignite

--- a/test/functional/vehicle_second_gear_test.rb
+++ b/test/functional/vehicle_second_gear_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleSecondGearTest < MiniTest::Test
+class VehicleSecondGearTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.ignite

--- a/test/functional/vehicle_stalled_test.rb
+++ b/test/functional/vehicle_stalled_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleStalledTest < MiniTest::Test
+class VehicleStalledTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.ignite

--- a/test/functional/vehicle_test.rb
+++ b/test/functional/vehicle_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleTest < MiniTest::Test
+class VehicleTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
   end

--- a/test/functional/vehicle_third_gear_test.rb
+++ b/test/functional/vehicle_third_gear_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleThirdGearTest < MiniTest::Test
+class VehicleThirdGearTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.ignite

--- a/test/functional/vehicle_unsaved_test.rb
+++ b/test/functional/vehicle_unsaved_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleUnsavedTest < MiniTest::Test
+class VehicleUnsavedTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
   end

--- a/test/functional/vehicle_with_event_attributes_test.rb
+++ b/test/functional/vehicle_with_event_attributes_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleWithEventAttributesTest < MiniTest::Test
+class VehicleWithEventAttributesTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
     @vehicle.state_event = 'ignite'

--- a/test/functional/vehicle_with_parallel_events_test.rb
+++ b/test/functional/vehicle_with_parallel_events_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'files/models/vehicle'
 
-class VehicleWithParallelEventsTest < MiniTest::Test
+class VehicleWithParallelEventsTest < Minitest::Test
   def setup
     @vehicle = Vehicle.new
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ end
 require 'minitest/reporters'
 Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new]
 
-class StateMachinesTest < MiniTest::Test
+class StateMachinesTest < Minitest::Test
   def before_setup
     super
     StateMachines::Integrations.reset


### PR DESCRIPTION
The MiniTest name space has been deprecated since minitest 5.19 and causes errors with ruby3.3