### PR TITLE
chore: test ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3'']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 platform :mri do
-  gem 'pry-byebug'
+  gem 'debug'
 end
 
 gem 'minitest-reporters'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'state_machines'
 require 'minitest/autorun'
 begin
-  require 'pry-byebug'
+  require 'debug'
 rescue LoadError
 end
 require 'minitest/reporters'

--- a/test/unit/machine/machine_with_event_matchers_test.rb
+++ b/test/unit/machine/machine_with_event_matchers_test.rb
@@ -15,9 +15,14 @@ class MachineWithEventMatchersTest < StateMachinesTest
   end
 
   def test_should_not_allow_configurations
-    exception = assert_raises(ArgumentError) { @machine.event(StateMachines::BlacklistMatcher.new([:park]), human_name: 'Park') }
-    assert_equal 'Cannot configure events when using matchers (using {:human_name=>"Park"})', exception.message
+    expected_hash = { human_name: 'Parked' }
+    expected_message = "Cannot configure states when using matchers (using #{expected_hash.inspect})"
+    exception = assert_raises(ArgumentError) do
+      @machine.state(StateMachines::BlacklistMatcher.new([:parked]), human_name: 'Parked')
+    end
+    assert_equal expected_message, exception.message
   end
+
 
   def test_should_track_referenced_events
     @machine.event(StateMachines::BlacklistMatcher.new([:park]))

--- a/test/unit/machine/machine_with_state_matchers_test.rb
+++ b/test/unit/machine/machine_with_state_matchers_test.rb
@@ -15,8 +15,12 @@ class MachineWithStateMatchersTest < StateMachinesTest
   end
 
   def test_should_not_allow_configurations
-    exception = assert_raises(ArgumentError) { @machine.state(StateMachines::BlacklistMatcher.new([:parked]), human_name: 'Parked') }
-    assert_equal 'Cannot configure states when using matchers (using {:human_name=>"Parked"})', exception.message
+    expected_hash = { human_name: 'Parked' }
+    expected_message = "Cannot configure states when using matchers (using #{expected_hash.inspect})"
+    exception = assert_raises(ArgumentError) do
+      @machine.state(StateMachines::BlacklistMatcher.new([:parked]), human_name: 'Parked')
+    end
+    assert_equal expected_message, exception.message
   end
 
   def test_should_track_referenced_states


### PR DESCRIPTION
The syntax of the hash.inspect changed in ruby 3.4 , so i updated the tests