### PR TITLE
feat: introduce STDIO renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,24 @@ class Vehicle
     end
 
     ...
+
+    ### Default STDIORenderer
+
+    State Machines now includes a default STDIORenderer for debugging state machines without external dependencies. This renderer can be used to visualize the state machine in the console.
+
+    To use the renderer, simply call the `draw` method on the state machine:
+
+    ```ruby
+    vehicle = Vehicle.new
+    Vehicle.state_machine.draw # Outputs the state machine diagram to the console
+    ```
+
+    You can customize the output by passing in options to the `draw` method, such as the output stream:
+
+    ```ruby
+    vehicle = Vehicle.new
+    Vehicle.state_machine.draw(io: $stderr) # Outputs the state machine diagram to stderr
+    ```
   end
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,5 @@ Rake::TestTask.new(:unit) do |t|
 end
 
 desc 'Default: run all tests.'
-task default: [:unit, :functional]
+task test: [:unit, :functional]
+task default: :test

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'state_machines'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require 'irb'
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/state_machines.rb
+++ b/lib/state_machines.rb
@@ -3,3 +3,4 @@
 require 'state_machines/version'
 require 'state_machines/core'
 require 'state_machines/core_ext'
+require 'state_machines/stdio_renderer'

--- a/lib/state_machines/branch.rb
+++ b/lib/state_machines/branch.rb
@@ -121,8 +121,8 @@ module StateMachines
       end
     end
 
-    def draw(graph, event, valid_states)
-     fail NotImplementedError
+    def draw(graph, event, valid_states, io = $stdout)
+      machine.renderer.draw_branch(self, graph, event, valid_states, io)
     end
 
   protected

--- a/lib/state_machines/event.rb
+++ b/lib/state_machines/event.rb
@@ -182,8 +182,8 @@ module StateMachines
     end
 
 
-    def draw(graph, options = {})
-      fail NotImplementedError
+    def draw(graph, options = {}, io = $stdout)
+      machine.renderer.draw_event(self, graph, options, io)
     end
 
     # Generates a nicely formatted description of this event's contents.

--- a/lib/state_machines/machine.rb
+++ b/lib/state_machines/machine.rb
@@ -452,6 +452,12 @@ module StateMachines
       # Default messages to use for validation errors in ORM integrations
       attr_accessor :default_messages
       attr_accessor :ignore_method_conflicts
+      attr_writer :renderer
+
+      def renderer
+        return @renderer if @renderer
+        STDIORenderer
+      end
     end
     @default_messages = {
         invalid: 'is invalid',
@@ -1876,8 +1882,12 @@ module StateMachines
     end
 
 
-    def draw(*)
-      fail NotImplementedError
+    def renderer
+      self.class.renderer
+    end
+
+    def draw(**options)
+      renderer.draw_machine(self, **options)
     end
 
     # Determines whether an action hook was defined for firing attribute-based

--- a/lib/state_machines/state.rb
+++ b/lib/state_machines/state.rb
@@ -241,8 +241,8 @@ module StateMachines
       end
     end
 
-    def draw(graph, options = {})
-      fail NotImplementedError
+    def draw(graph, options = {}, io = $stdout)
+      machine.renderer.draw_state(self, graph, options, io)
     end
 
     # Generates a nicely formatted description of this state's contents.

--- a/lib/state_machines/stdio_renderer.rb
+++ b/lib/state_machines/stdio_renderer.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module StateMachines
+  module STDIORenderer
+    def self.draw_machine(machine, **options)
+      io = options[:io] || $stdout
+      draw_class(machine: machine, io: io)
+      draw_states(machine: machine, io: io)
+      draw_events(machine: machine, io: io)
+    end
+
+    def self.draw_class(machine:, io:)
+      io.puts "Class: #{machine.owner_class.name}"
+    end
+
+    def self.draw_states(machine:, io:)
+      io.puts "  States:"
+      if machine.states.to_a.empty?
+        io.puts "    - None"
+      else
+        machine.states.each do |state|
+          io.puts "    - #{state.name}"
+        end
+      end
+    end
+
+    def self.draw_events(machine:, io:)
+      io.puts "  Events:"
+      if machine.events.to_a.empty?
+        io.puts "    - None"
+      else
+        machine.events.each do |event|
+          io.puts "    - #{event.name}"
+          event.branches.each do |branch|
+            branch.state_requirements.each do |requirement|
+              io.puts "      - #{requirement[:from].values.join(', ')} => #{requirement[:to].values.join(', ')}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/state_machines/stdio_renderer.rb
+++ b/lib/state_machines/stdio_renderer.rb
@@ -2,18 +2,17 @@
 
 module StateMachines
   module STDIORenderer
-    def self.draw_machine(machine, **options)
-      io = options[:io] || $stdout
+    module_function def draw_machine(machine, io: $stdout)
       draw_class(machine: machine, io: io)
       draw_states(machine: machine, io: io)
       draw_events(machine: machine, io: io)
     end
 
-    def self.draw_class(machine:, io:)
+    module_function def draw_class(machine:, io: $stdout)
       io.puts "Class: #{machine.owner_class.name}"
     end
 
-    def self.draw_states(machine:, io:)
+    module_function def draw_states(machine:, io: $stdout)
       io.puts "  States:"
       if machine.states.to_a.empty?
         io.puts "    - None"
@@ -24,7 +23,22 @@ module StateMachines
       end
     end
 
-    def self.draw_events(machine:, io:)
+    module_function def draw_event(event, graph, options: {}, io: $stdout)
+      io = io || options[:io] || $stdout
+      io.puts "  Event: #{event.name}"
+    end
+
+    module_function def draw_branch(branch, graph, event, options: {}, io: $stdout)
+      io = io || options[:io] || $stdout
+      io.puts "  Branch: #{branch.inspect}"
+    end
+
+    module_function def draw_state(state, graph, options: {}, io: $stdout)
+      io =  io || options[:io] || $stdout
+      io.puts "  State: #{state.name}"
+    end
+
+    module_function def draw_events(machine:, io: $stdout)
       io.puts "  Events:"
       if machine.events.to_a.empty?
         io.puts "    - None"

--- a/test/unit/stdio_renderer_test.rb
+++ b/test/unit/stdio_renderer_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class STDIORendererTest < Minitest::Test
+  def test_draw_machine
+    machine = StateMachines::Machine.new(Class.new) do
+      state :parked
+      state :idling
+      event :ignite do
+        transition parked: :idling
+      end
+    end
+
+    io = StringIO.new
+    StateMachines::STDIORenderer.draw_machine(machine, io: io)
+
+    assert_includes(io.string, "Class: ")
+    assert_includes(io.string, "States:")
+    assert_includes(io.string, "parked")
+    assert_includes(io.string, "idling")
+    assert_includes(io.string, "Events:")
+    assert_includes(io.string, "ignite")
+    assert_includes(io.string, "parked => idling")
+  end
+  def test_draw_machine_with_no_events
+    machine = StateMachines::Machine.new(Class.new) do
+      state :parked
+    end
+
+    io = StringIO.new
+    StateMachines::STDIORenderer.draw_machine(machine, io: io)
+
+    assert_includes(io.string, "Class: ")
+    assert_includes(io.string, "States:")
+    assert_includes(io.string, "parked")
+    assert_includes(io.string, "Events:")
+    assert_includes(io.string, "None")
+  end
+
+  def test_draw_machine_with_custom_io
+    machine = StateMachines::Machine.new(Class.new) do
+      state :parked
+    end
+
+    io = StringIO.new
+    StateMachines::STDIORenderer.draw_machine(machine, io: io)
+
+    assert_includes(io.string, "Class: ")
+    assert_includes(io.string, "States:")
+    assert_includes(io.string, "parked")
+    assert_includes(io.string, "Events:")
+    assert_includes(io.string, "None")
+  end
+end

--- a/test/unit/stdio_renderer_test.rb
+++ b/test/unit/stdio_renderer_test.rb
@@ -13,7 +13,7 @@ class STDIORendererTest < Minitest::Test
     end
 
     io = StringIO.new
-    StateMachines::STDIORenderer.draw_machine(machine, io: io)
+    machine.draw(io: io)
 
     assert_includes(io.string, "Class: ")
     assert_includes(io.string, "States:")
@@ -29,7 +29,7 @@ class STDIORendererTest < Minitest::Test
     end
 
     io = StringIO.new
-    StateMachines::STDIORenderer.draw_machine(machine, io: io)
+    machine.draw(io: io)
 
     assert_includes(io.string, "Class: ")
     assert_includes(io.string, "States:")
@@ -44,12 +44,74 @@ class STDIORendererTest < Minitest::Test
     end
 
     io = StringIO.new
-    StateMachines::STDIORenderer.draw_machine(machine, io: io)
+    machine.draw(io: io)
 
     assert_includes(io.string, "Class: ")
     assert_includes(io.string, "States:")
     assert_includes(io.string, "parked")
     assert_includes(io.string, "Events:")
     assert_includes(io.string, "None")
+  end
+
+  def test_draw_class
+    machine = StateMachines::Machine.new(Class.new) { }
+    io = StringIO.new
+    machine.renderer.draw_class(machine: machine, io: io)
+    assert_includes(io.string, "Class: ")
+  end
+
+  def test_draw_states
+    machine = StateMachines::Machine.new(Class.new) do
+      state :parked
+      state :idling
+    end
+    io = StringIO.new
+    machine.renderer.draw_states(machine: machine, io: io)
+    assert_includes(io.string, "States:")
+    assert_includes(io.string, "parked")
+    assert_includes(io.string, "idling")
+  end
+
+  def test_draw_event
+    machine = StateMachines::Machine.new(Class.new) { }
+    event = StateMachines::Event.new(machine, :ignite)
+    graph = {}
+    io = StringIO.new
+    machine.renderer.draw_event(event, graph, options: {}, io: io)
+    assert_includes(io.string, "Event: ignite")
+  end
+
+  def test_draw_branch
+    machine = StateMachines::Machine.new(Class.new) { }
+    branch = StateMachines::Branch.new
+    graph = {}
+    event = StateMachines::Event.new(machine, :ignite)
+    io = StringIO.new
+    machine.renderer.draw_branch(branch, graph, event, options: {}, io: io)
+    assert_includes(io.string, "Branch: ")
+  end
+
+  def test_draw_state
+    machine = StateMachines::Machine.new(Class.new) { }
+    state = StateMachines::State.new(machine, :parked)
+    graph = {}
+    io = StringIO.new
+    machine.renderer.draw_state(state, graph, options: {}, io: io)
+    assert_includes(io.string, "State: parked")
+  end
+
+  def test_draw_events
+    machine = StateMachines::Machine.new(Class.new) do
+      state :parked
+      state :idling
+      event :ignite do
+        transition parked: :idling
+      end
+    end
+    io = StringIO.new
+    machine.renderer.draw_events(machine: machine, io: io)
+    assert_includes(io.string, "Events:")
+    assert_includes(io.string, "ignite")
+    assert_includes(io.string, "parked => idling")
   end
 end


### PR DESCRIPTION
In this PR we introduces a default STDIORenderer for debugging state machines without external dependencies. 


The draw methods in Event, Branch, State, and Machine now use the configured renderer by default. 

Backward compatibility was kept since graphiz gem just overwrite the draw method for now. 

I will change it later.