### PR TITLE
Add `all.except` as an alias for `all -`

### DIFF
--- a/lib/state_machines/matcher.rb
+++ b/lib/state_machines/matcher.rb
@@ -35,6 +35,7 @@ module StateMachines
     def -(blacklist)
       BlacklistMatcher.new(blacklist)
     end
+    alias_method :except, :-
 
     # Always returns true
     def matches?(value, context = {})


### PR DESCRIPTION
Before:
```ruby
event :mark_ready do
  transition any - :ready => :ready
end
```

Now allowed:
```ruby
event :mark_ready do
  transition any.except(:ready) => :ready
end
```