### PR TITLE
Add run_action as a hash option

### DIFF
--- a/lib/state_machines/transition.rb
+++ b/lib/state_machines/transition.rb
@@ -158,7 +158,14 @@ module StateMachines
     #   transition.perform(Time.now)        # => Passes in additional arguments and runs the +save+ action
     #   transition.perform(Time.now, false) # => Passes in additional arguments and only sets the state attribute
     def perform(*args)
-      run_action = [true, false].include?(args.last) ? args.pop : true
+      run_action = true
+
+      if [true, false].include?(args.last)
+        run_action = args.pop
+      elsif args.last.is_a?(Hash) && args.last.key?(:run_action)
+        run_action = args.last.delete(:run_action)
+      end
+
       self.args = args
 
       # Run the transition


### PR DESCRIPTION
Ported forward from https://github.com/state-machines/state_machines/pull/118

Currently the only way to skip "running the action" is to send `false` as the final positional argument but that's impossible with hash-based options.

This PR adds a `run_action` key in addition to the traditional positional argument handling.