### PR TITLE
feat: show owner class and source location in method conflict warnings

### DIFF
--- a/lib/state_machines/async_mode/async_events.rb
+++ b/lib/state_machines/async_mode/async_events.rb
@@ -114,8 +114,7 @@ module StateMachines
         end
 
         Async do
-          # Use the bang version which raises exceptions on failure
-          machine.events[event_name].fire(self, *args) || raise(StateMachines::InvalidTransition.new(self, machine, event_name))
+          fire_with_bang(machine, event_name, *args)
         end
       end
 
@@ -140,11 +139,11 @@ module StateMachines
 
         if defined?(::Async::Task) && ::Async::Task.current?
           # Already in async context, just fire directly with bang behavior
-          machine.events[event_name].fire(self, *args) || raise(StateMachines::InvalidTransition.new(self, machine, event_name))
+          fire_with_bang(machine, event_name, *args)
         else
           # Create async context and wait for result (may raise exception)
           Async do
-            machine.events[event_name].fire(self, *args) || raise(StateMachines::InvalidTransition.new(self, machine, event_name))
+            fire_with_bang(machine, event_name, *args)
           end.wait
         end
       end
@@ -198,6 +197,11 @@ module StateMachines
       end
 
       private
+
+      # Fires the event on the given machine, raising InvalidTransition on failure
+      def fire_with_bang(machine, event_name, *)
+        machine.events[event_name].fire(self, *) || raise(StateMachines::InvalidTransition.new(self, machine, event_name))
+      end
 
       # Check if this event method should have async versions
       def async_method_for_event?(event_method)

--- a/lib/state_machines/machine.rb
+++ b/lib/state_machines/machine.rb
@@ -355,7 +355,7 @@ module StateMachines
   # module that gets included in every Object.  As a result, state_machine will
   # generate the following warning:
   #
-  #   Instance method "open" is already defined in Object, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.
+  #   Instance method "open" is already defined in Object, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on Vehicle.
   #
   # Even though you may not be using Kernel's implementation of the "open"
   # instance method, state_machine isn't aware of this and, as a result, stays
@@ -517,8 +517,7 @@ module StateMachines
 
       if block_given?
         if !self.class.ignore_method_conflicts && (conflicting_ancestor = owner_class_ancestor_has_method?(scope, method))
-          ancestor_name = conflicting_ancestor.name && !conflicting_ancestor.name.empty? ? conflicting_ancestor.name : conflicting_ancestor.to_s
-          warn "#{scope == :class ? 'Class' : 'Instance'} method \"#{method}\" is already defined in #{ancestor_name}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true."
+          warn method_conflict_message(scope, method, conflicting_ancestor)
         else
           name = self.name
           helper_module.class_eval do

--- a/lib/state_machines/machine/utilities.rb
+++ b/lib/state_machines/machine/utilities.rb
@@ -55,6 +55,33 @@ module StateMachines
         target.method_defined?(method) || target.private_method_defined?(method)
       end
 
+      # Generates the warning message for a method conflict, including where
+      # the conflicting method was defined (when it has a Ruby source
+      # location) and which class the state machine is being defined on
+      def method_conflict_message(scope, method, defined_in)
+        scope_label = scope == :class ? 'Class' : 'Instance'
+        defined_in_name = defined_in.name && !defined_in.name.empty? ? defined_in.name : defined_in.to_s
+        location = conflicting_method_location(scope, method, defined_in)
+        location_label = location ? " at #{location[0]}:#{location[1]}" : ''
+
+        "#{scope_label} method \"#{method}\" is already defined in #{defined_in_name}#{location_label}, " \
+          'use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. ' \
+          "Defining #{name.inspect} state machine on #{owner_class}."
+      end
+
+      # Looks up the source location of the conflicting method.  Returns nil
+      # for methods without a Ruby source (e.g. C-defined methods like
+      # Kernel#fail) and for the machine's own helper modules, where the
+      # location would just point inside this gem
+      def conflicting_method_location(scope, method, defined_in)
+        return if @helper_modules.value?(defined_in)
+
+        target = scope == :class && defined_in.is_a?(Class) ? defined_in.singleton_class : defined_in
+        target.instance_method(method).source_location
+      rescue NameError
+        nil
+      end
+
       # Pluralizes the given word using #pluralize (if available) or simply
       # adding an "s" to the end of the word
       def pluralize(word)

--- a/lib/state_machines/state.rb
+++ b/lib/state_machines/state.rb
@@ -289,8 +289,8 @@ module StateMachines
     def add_predicate
       predicate_method = "#{qualified_name}?"
 
-      if machine.send(:owner_class_ancestor_has_method?, :instance, predicate_method)
-        warn_about_method_conflict(predicate_method, machine.owner_class.ancestors.first)
+      if (conflicting_ancestor = machine.send(:owner_class_ancestor_has_method?, :instance, predicate_method))
+        warn_about_method_conflict(predicate_method, conflicting_ancestor)
       elsif machine.send(:owner_class_has_method?, :instance, predicate_method)
         warn_about_method_conflict(predicate_method, machine.owner_class)
       else
@@ -308,7 +308,7 @@ module StateMachines
     def warn_about_method_conflict(method, defined_in)
       return if StateMachines::Machine.ignore_method_conflicts
 
-      warn "Instance method #{method.inspect} is already defined in #{defined_in.inspect}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true."
+      warn machine.send(:method_conflict_message, :instance, method, defined_in)
     end
   end
 end

--- a/lib/state_machines/transition.rb
+++ b/lib/state_machines/transition.rb
@@ -407,9 +407,7 @@ module StateMachines
       else
         # Capture current fiber's Thread.current storage to preserve object identity
         # This is needed for compatibility but has limitations with dynamic assignments
-        parent_fiber_locals = Thread.current.keys.each_with_object({}) do |key, storage|
-          storage[key] = Thread.current[key]
-        end
+        parent_fiber_locals = capture_thread_locals
 
         # Create a new fiber to run the block
         fiber = Fiber.new do
@@ -428,11 +426,7 @@ module StateMachines
             end
 
             # Export the final thread storage state along with the result
-            thread_storage = Thread.current.keys.each_with_object({}) do |key, storage|
-              storage[key] = Thread.current[key]
-            end
-
-            [halted ? :halted : :completed, thread_storage]
+            [halted ? :halted : :completed, capture_thread_locals]
           rescue StandardError => e
             # Store the exception for re-raising
             [:error, e]
@@ -456,6 +450,14 @@ module StateMachines
           # Fiber completed, return whether it was halted
           result_value == :halted
         end
+      end
+    end
+
+    # Snapshots the current fiber's Thread.current storage, preserving object
+    # identity of the stored values
+    def capture_thread_locals
+      Thread.current.keys.each_with_object({}) do |key, storage|
+        storage[key] = Thread.current[key]
       end
     end
 

--- a/test/unit/event/event_with_conflicting_helpers_before_definition_test.rb
+++ b/test/unit/event/event_with_conflicting_helpers_before_definition_test.rb
@@ -53,7 +53,8 @@ class EventWithConflictingHelpersBeforeDefinitionTest < StateMachinesTest
 
   def test_should_output_warning
     expected = %w[can_ignite? ignite_transition ignite ignite!].map do |method|
-      "Instance method \"#{method}\" is already defined in #{@superclass}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n"
+      location = @superclass.instance_method(method).source_location.join(':')
+      "Instance method \"#{method}\" is already defined in #{@superclass} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{@klass}.\n"
     end.join
 
     assert_equal expected, $stderr.string

--- a/test/unit/machine/machine_with_class_helpers_test.rb
+++ b/test/unit/machine/machine_with_class_helpers_test.rb
@@ -61,7 +61,9 @@ class MachineWithClassHelpersTest < StateMachinesTest
 
     machine.define_helper(:class, :park) {}
 
-    assert_equal "Class method \"park\" is already defined in #{superclass}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    location = superclass.method(:park).source_location.join(':')
+
+    assert_equal "Class method \"park\" is already defined in #{superclass} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -81,7 +83,9 @@ class MachineWithClassHelpersTest < StateMachinesTest
 
     machine.define_helper(:class, :park) {}
 
-    assert_equal "Class method \"park\" is already defined in #{superclass1}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    location = superclass1.method(:park).source_location.join(':')
+
+    assert_equal "Class method \"park\" is already defined in #{superclass1} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -100,7 +104,9 @@ class MachineWithClassHelpersTest < StateMachinesTest
 
     machine.define_helper(:class, :park) {}
 
-    assert_equal "Class method \"park\" is already defined in #{mod}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    location = mod.instance_method(:park).source_location.join(':')
+
+    assert_equal "Class method \"park\" is already defined in #{mod} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -159,7 +165,7 @@ class MachineWithClassHelpersTest < StateMachinesTest
     @machine.define_helper(:class, :states) {}
     @machine.define_helper(:class, :states) {}
 
-    assert_equal "Class method \"states\" is already defined in #{@klass} :state class helpers, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Class method \"states\" is already defined in #{@klass} :state class helpers, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{@klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end

--- a/test/unit/machine/machine_with_conflicting_helpers_before_definition_test.rb
+++ b/test/unit/machine/machine_with_conflicting_helpers_before_definition_test.rb
@@ -159,19 +159,23 @@ class MachineWithConflictingHelpersBeforeDefinitionTest < StateMachinesTest
 
   def test_should_output_warning
     expected = [
-      'Instance method "state_events"',
-      'Instance method "state_transitions"',
-      'Instance method "fire_state_event"',
-      'Instance method "state_paths"',
-      'Class method "human_state_name"',
-      'Class method "human_state_event_name"',
-      'Instance method "state_name"',
-      'Instance method "human_state_name"',
-      'Class method "with_state"',
-      'Class method "with_states"',
-      'Class method "without_state"',
-      'Class method "without_states"'
-    ].map { |method| "#{method} is already defined in #{@superclass}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n" }.join
+      %w[Instance state_events],
+      %w[Instance state_transitions],
+      %w[Instance fire_state_event],
+      %w[Instance state_paths],
+      %w[Class human_state_name],
+      %w[Class human_state_event_name],
+      %w[Instance state_name],
+      %w[Instance human_state_name],
+      %w[Class with_state],
+      %w[Class with_states],
+      %w[Class without_state],
+      %w[Class without_states]
+    ].map do |scope, method|
+      target = scope == 'Class' ? @superclass.singleton_class : @superclass
+      location = target.instance_method(method).source_location.join(':')
+      "#{scope} method \"#{method}\" is already defined in #{@superclass} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{@klass}.\n"
+    end.join
 
     assert_equal expected, $stderr.string
   end

--- a/test/unit/machine/machine_with_instance_helpers_test.rb
+++ b/test/unit/machine/machine_with_instance_helpers_test.rb
@@ -59,7 +59,9 @@ class MachineWithInstanceHelpersTest < StateMachinesTest
 
     machine.define_helper(:instance, :park) {}
 
-    assert_equal "Instance method \"park\" is already defined in #{superclass}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    location = superclass.instance_method(:park).source_location.join(':')
+
+    assert_equal "Instance method \"park\" is already defined in #{superclass} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -79,7 +81,9 @@ class MachineWithInstanceHelpersTest < StateMachinesTest
 
     machine.define_helper(:instance, :park) {}
 
-    assert_equal "Instance method \"park\" is already defined in #{superclass1}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    location = superclass1.instance_method(:park).source_location.join(':')
+
+    assert_equal "Instance method \"park\" is already defined in #{superclass1} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -98,7 +102,9 @@ class MachineWithInstanceHelpersTest < StateMachinesTest
 
     machine.define_helper(:instance, :park) {}
 
-    assert_equal "Instance method \"park\" is already defined in #{mod}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    location = mod.instance_method(:park).source_location.join(':')
+
+    assert_equal "Instance method \"park\" is already defined in #{mod} at #{location}, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end
@@ -157,7 +163,7 @@ class MachineWithInstanceHelpersTest < StateMachinesTest
     @machine.define_helper(:instance, :park) {}
     @machine.define_helper(:instance, :park) {}
 
-    assert_equal "Instance method \"park\" is already defined in #{@klass} :state instance helpers, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true.\n", $stderr.string
+    assert_equal "Instance method \"park\" is already defined in #{@klass} :state instance helpers, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true. Defining :state state machine on #{@klass}.\n", $stderr.string
   ensure
     $stderr = @original_stderr
   end

--- a/test/unit/state/state_with_conflicting_helpers_before_definition_test.rb
+++ b/test/unit/state/state_with_conflicting_helpers_before_definition_test.rb
@@ -27,8 +27,10 @@ class StateWithConflictingHelpersBeforeDefinitionTest < StateMachinesTest
   end
 
   def test_should_output_warning
+    location = @superclass.instance_method(:parked?).source_location.join(':')
+
     assert_match(
-      /Instance method "parked\?" is already defined in #<Class:.*>, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true./, $stderr.string
+      /Instance method "parked\?" is already defined in #<Class:.*> at #{Regexp.escape(location)}, use generic helper instead or set StateMachines::Machine\.ignore_method_conflicts = true\. Defining :state state machine on #<Class:.*>\./, $stderr.string
     )
   end
 end

--- a/test/unit/state/state_with_conflicting_machine_name_test.rb
+++ b/test/unit/state/state_with_conflicting_machine_name_test.rb
@@ -20,7 +20,7 @@ class StateWithConflictingMachineNameTest < StateMachinesTest
     StateMachines::State.new(@state_machine, :state)
 
     assert_match(
-      /Instance method "state\?" is already defined in #<Class:.*>, use generic helper instead or set StateMachines::Machine.ignore_method_conflicts = true./, $stderr.string
+      /Instance method "state\?" is already defined in #<Class:.*> :state instance helpers, use generic helper instead or set StateMachines::Machine\.ignore_method_conflicts = true\. Defining :state state machine on #<Class:.*>\./, $stderr.string
     )
   end
 end


### PR DESCRIPTION
Previously the method_conflict_message was not descriptive.  Yes, it already defined , but where ?

This PR remove the guessing game. 

For people that enjoy pain and puzzles, monkey patch `#method_conflict_message` to keep old behavior .